### PR TITLE
Implement ticket clustering pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+overview.xlsx

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,24 @@
+embedding:
+  model_name: paraphrase-multilingual-MiniLM-L12-v2
+  batch_size: 256
+  n_jobs: 8
+
+umap:
+  enabled: true
+  n_neighbors: 15
+  min_dist: 0.0
+  n_components: 15
+
+hdbscan:
+  min_cluster_size: 25
+  min_samples: null
+  cluster_selection_epsilon: 0.0
+
+labeling:
+  keywords: ["PKI","SNC","APEX","SAP","GUI","Login","Anmeldung","Dashboard","Bug","Fehler"]
+  yake_topk: 10
+  yake_max_ngram: 3
+
+output:
+  top_n_clusters: 10
+  include_noise: false

--- a/main.py
+++ b/main.py
@@ -1,0 +1,69 @@
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from ticket_clustering.preprocess import preprocess_dataframe
+from ticket_clustering.embedding import compute_embeddings
+from ticket_clustering.cluster import reduce_embeddings, cluster_embeddings
+from ticket_clustering.labeling import label_clusters
+from ticket_clustering.report import aggregate_report, write_excel_report
+
+
+def load_input(path: Path) -> pd.DataFrame:
+    if path.suffix.lower() == ".csv":
+        return pd.read_csv(path)
+    return pd.read_excel(path)
+
+
+def main(args) -> None:
+    with open(args.config, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    df = load_input(Path(args.input))
+    mapping = preprocess_dataframe(df, domain_terms=config.get("labeling", {}).get("keywords", []))
+
+    texts_norm = list(mapping.keys())
+    occurrences = [v[0] for v in mapping.values()]
+    original_texts = [v[1] for v in mapping.values()]
+
+    emb_conf = config.get("embedding", {})
+    embeddings = compute_embeddings(
+        texts_norm,
+        model_name=emb_conf.get("model_name", "paraphrase-multilingual-MiniLM-L12-v2"),
+        batch_size=emb_conf.get("batch_size", 256),
+        n_jobs=emb_conf.get("n_jobs", 8),
+    )
+
+    reduced = reduce_embeddings(embeddings, config.get("umap", {}))
+    cluster_ids = cluster_embeddings(reduced, config.get("hdbscan", {}))
+
+    label_conf = config.get("labeling", {})
+    cluster_name_map = label_clusters(
+        original_texts,
+        list(cluster_ids),
+        keywords=label_conf.get("keywords", []),
+        yake_topk=label_conf.get("yake_topk", 10),
+        yake_max_ngram=label_conf.get("yake_max_ngram", 3),
+    )
+
+    out_conf = config.get("output", {})
+    kpis, top_clusters = aggregate_report(
+        original_texts,
+        occurrences,
+        list(cluster_ids),
+        cluster_name_map,
+        top_n=out_conf.get("top_n_clusters", 10),
+        include_noise=out_conf.get("include_noise", False),
+    )
+
+    write_excel_report(kpis, top_clusters, args.output)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Ticket clustering pipeline")
+    parser.add_argument("input", help="Input CSV or Excel file")
+    parser.add_argument("--config", default="config.yaml")
+    parser.add_argument("--output", default="overview.xlsx")
+    main(parser.parse_args())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pandas
+numpy
+sentence-transformers
+umap-learn
+hdbscan
+yake
+openpyxl

--- a/ticket_clustering/cluster.py
+++ b/ticket_clustering/cluster.py
@@ -1,0 +1,29 @@
+from typing import Dict
+
+import numpy as np
+import umap
+import hdbscan
+
+
+def reduce_embeddings(embeddings: np.ndarray, config: Dict) -> np.ndarray:
+    """Optionally reduce embeddings using UMAP."""
+    if not config.get("enabled", True):
+        return embeddings
+    reducer = umap.UMAP(
+        n_neighbors=config.get("n_neighbors", 15),
+        min_dist=config.get("min_dist", 0.0),
+        n_components=config.get("n_components", 15),
+        metric="cosine",
+    )
+    return reducer.fit_transform(embeddings)
+
+
+def cluster_embeddings(embeddings: np.ndarray, config: Dict) -> np.ndarray:
+    """Cluster embeddings using HDBSCAN and return labels."""
+    clusterer = hdbscan.HDBSCAN(
+        min_cluster_size=config.get("min_cluster_size", 25),
+        min_samples=config.get("min_samples"),
+        metric="euclidean",
+        cluster_selection_epsilon=config.get("cluster_selection_epsilon", 0.0),
+    )
+    return clusterer.fit_predict(embeddings)

--- a/ticket_clustering/embedding.py
+++ b/ticket_clustering/embedding.py
@@ -1,0 +1,16 @@
+from typing import Iterable
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+
+def compute_embeddings(texts: Iterable[str], model_name: str, batch_size: int = 256, n_jobs: int = 8) -> np.ndarray:
+    """Embed texts using SentenceTransformer and return numpy array of float32."""
+    model = SentenceTransformer(model_name)
+    emb = model.encode(
+        list(texts),
+        batch_size=batch_size,
+        show_progress_bar=False,
+        convert_to_numpy=True,
+    ).astype("float32")
+    return emb

--- a/ticket_clustering/labeling.py
+++ b/ticket_clustering/labeling.py
@@ -1,0 +1,28 @@
+from collections import defaultdict
+from typing import Dict, List
+
+import yake
+
+
+def label_clusters(texts: List[str], labels: List[int], keywords: List[str], yake_topk: int = 10, yake_max_ngram: int = 3) -> Dict[int, str]:
+    """Assign human readable labels for each cluster."""
+    texts_per_cluster: Dict[int, List[str]] = defaultdict(list)
+    for t, l in zip(texts, labels):
+        texts_per_cluster[l].append(t)
+
+    extractor = yake.KeywordExtractor(top=yake_topk, n=yake_max_ngram)
+    kw_lower = [k.lower() for k in keywords]
+    cluster_labels: Dict[int, str] = {}
+    for cid, items in texts_per_cluster.items():
+        block = " ".join(items)
+        label = None
+        for kw in kw_lower:
+            if kw in block.lower():
+                label = kw
+                break
+        if not label:
+            yk = extractor.extract_keywords(block)
+            if yk:
+                label = yk[0][0]
+        cluster_labels[cid] = (label or f"cluster_{cid}")[:60]
+    return cluster_labels

--- a/ticket_clustering/preprocess.py
+++ b/ticket_clustering/preprocess.py
@@ -1,0 +1,39 @@
+import re
+import unicodedata
+from typing import Dict, List, Tuple
+
+import pandas as pd
+
+# basic stop word list - German/English mix, excluding negations
+default_stop_words = {
+    "und", "oder", "aber", "the", "a", "an", "is", "ist", "im", "in", "am",
+    "mit", "auf", "zu", "für", "von", "der", "die", "das", "den", "des",
+}
+
+
+def normalize_text(text: str) -> str:
+    """Normalize text by lowercasing, unicode NFKC and removing punctuation."""
+    text = unicodedata.normalize("NFKC", text.lower())
+    text = re.sub(r"[^\w\s]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    tokens = [t for t in text.split() if t not in default_stop_words]
+    return " ".join(tokens)
+
+
+def preprocess_dataframe(df: pd.DataFrame, domain_terms: List[str] = None) -> Dict[str, Tuple[int, str]]:
+    """Return mapping normalized_text -> (occurrences, original_text)."""
+    domain_terms = domain_terms or []
+    mapping: Dict[str, Tuple[int, str]] = {}
+    for _, row in df.iterrows():
+        original = str(row["text"])
+        occ = int(row.get("occurrences", 1))
+        norm = normalize_text(original)
+        # ensure domain terms preserved
+        for term in domain_terms:
+            if term.lower() in original.lower() and term.lower() not in norm:
+                norm = f"{norm} {term.lower()}".strip()
+        if norm in mapping:
+            mapping[norm] = (mapping[norm][0] + occ, mapping[norm][1])
+        else:
+            mapping[norm] = (occ, original)
+    return mapping

--- a/ticket_clustering/report.py
+++ b/ticket_clustering/report.py
@@ -1,0 +1,56 @@
+from typing import Dict, List
+
+import pandas as pd
+
+
+def aggregate_report(texts: List[str], occurrences: List[int], cluster_ids: List[int], cluster_labels: Dict[int, str], top_n: int = 10, include_noise: bool = False):
+    df = pd.DataFrame({
+        "text": texts,
+        "occurrences": occurrences,
+        "cluster": cluster_ids,
+    })
+    df["label"] = df["cluster"].map(cluster_labels)
+
+    total_lines = df["occurrences"].sum()
+    unique_lines = df.shape[0]
+    noise_lines = df.loc[df["cluster"] == -1, "occurrences"].sum()
+    cluster_count = df.loc[df["cluster"] != -1, "cluster"].nunique()
+
+    cluster_agg = df.groupby("cluster").agg(
+        label=("label", "first"),
+        count_total=("occurrences", "sum"),
+        count_unique=("text", "nunique"),
+    ).reset_index()
+    cluster_agg["share_%"] = cluster_agg["count_total"] / total_lines * 100
+
+    non_noise = cluster_agg[cluster_agg["cluster"] != -1]
+    largest = non_noise["count_total"].max()
+    smallest = non_noise["count_total"].min()
+    median = non_noise["count_total"].median()
+
+    top_clusters = cluster_agg
+    if not include_noise:
+        top_clusters = top_clusters[top_clusters["cluster"] != -1]
+    top_clusters = top_clusters.sort_values("count_total", ascending=False).head(top_n)[
+        ["cluster", "label", "count_total", "share_%"]
+    ]
+
+    kpis = {
+        "input_rows_total": total_lines,
+        "unique_rows_total": unique_lines,
+        "cluster_count": cluster_count,
+        "noise_lines": noise_lines,
+        "largest_cluster": largest,
+        "smallest_cluster": smallest,
+        "median_cluster": median,
+    }
+
+    return kpis, top_clusters
+
+
+def write_excel_report(kpis: Dict, top_clusters: pd.DataFrame, path: str = "overview.xlsx") -> None:
+    with pd.ExcelWriter(path) as writer:
+        kpi_df = pd.DataFrame(list(kpis.items()), columns=["metric", "value"])
+        kpi_df.to_excel(writer, sheet_name="Overview", index=False)
+        startrow = len(kpi_df) + 2
+        top_clusters.to_excel(writer, sheet_name="Overview", index=False, startrow=startrow)


### PR DESCRIPTION
## Summary
- Add preprocessing, embedding, clustering, labeling, and reporting modules for ticket text grouping
- Provide main entry script and YAML configuration to run the full pipeline
- Include requirements and gitignore for caching and report output

## Testing
- `python -m py_compile main.py ticket_clustering/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68af25af7b7083339f3d5be8adb362a3