### PR TITLE
Simplify running ticket clustering with default input

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,15 @@ labeling:
 output:
   top_n_clusters: 10
   include_noise: false
+
+## Ausführung
+
+Lege die Eingabedatei als `input.xlsx` im Projektverzeichnis ab und starte
+den Prozess anschließend mit:
+
+```bash
+python main.py
+```
+
+Über die Argumente `--input`, `--config` und `--output` können bei Bedarf
+eigene Pfade angegeben werden.

--- a/main.py
+++ b/main.py
@@ -63,7 +63,15 @@ def main(args) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Ticket clustering pipeline")
-    parser.add_argument("input", help="Input CSV or Excel file")
-    parser.add_argument("--config", default="config.yaml")
-    parser.add_argument("--output", default="overview.xlsx")
+    parser.add_argument(
+        "--input",
+        default="input.xlsx",
+        help="Input CSV or Excel file (default: input.xlsx)",
+    )
+    parser.add_argument(
+        "--config", default="config.yaml", help="Configuration YAML file"
+    )
+    parser.add_argument(
+        "--output", default="overview.xlsx", help="Output Excel report"
+    )
     main(parser.parse_args())


### PR DESCRIPTION
## Summary
- Make `input.xlsx` the default dataset so `python main.py` works without arguments
- Document how to run the clustering script from the project root

## Testing
- `python -m py_compile main.py ticket_clustering/preprocess.py ticket_clustering/embedding.py ticket_clustering/cluster.py ticket_clustering/labeling.py ticket_clustering/report.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68af2f732d208333b90d0ca69db725cc