### PR TITLE
Clamp UMAP params to dataset size to avoid eigsh errors

### DIFF
--- a/ticket_clustering/cluster.py
+++ b/ticket_clustering/cluster.py
@@ -9,10 +9,20 @@ def reduce_embeddings(embeddings: np.ndarray, config: Dict) -> np.ndarray:
     """Optionally reduce embeddings using UMAP."""
     if not config.get("enabled", True):
         return embeddings
+
+    n_samples = embeddings.shape[0]
+
+    # UMAP requires parameters to be smaller than the number of samples.
+    if n_samples <= 1:
+        return embeddings
+
+    n_neighbors = min(config.get("n_neighbors", 15), n_samples - 1)
+    n_components = min(config.get("n_components", 15), n_samples - 1)
+
     reducer = umap.UMAP(
-        n_neighbors=config.get("n_neighbors", 15),
+        n_neighbors=n_neighbors,
         min_dist=config.get("min_dist", 0.0),
-        n_components=config.get("n_components", 15),
+        n_components=n_components,
         metric="cosine",
     )
     return reducer.fit_transform(embeddings)


### PR DESCRIPTION
## Summary
- prevent UMAP reduction from requesting more neighbors/components than samples
- handle extremely small embedding sets without crashing

## Testing
- `python -m pycodestyle ticket_clustering/cluster.py main.py` *(fails: No module named pycodestyle)*
- `pip install pycodestyle` *(fails: Could not find a version that satisfies the requirement pycodestyle)*
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68af324ec7908333a9601ced74fb030b